### PR TITLE
Improved error handling example

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,11 +161,16 @@ $connection->setProxy(array(
 <p>After every request you should validate it was a success.</p>
 
 <pre>
-$statues = $connection->post("statuses/update", array("status" => "hello world"));
-if ($connection->getLastHttpCode() == 200) {
-    // Tweet posted succesfully
-} else {
-    // Handle error case
+try {
+    $statues = $connection->post("statuses/update", array("status" => "hello world"));
+	
+    if ($connection->getLastHttpCode() == 200) {
+        // Tweet posted succesfully
+    } else {
+        // Handle error case
+    }
+} catch (TwitterOAuthException $e) {
+    // Handle exception
 }
 </pre>
 


### PR DESCRIPTION
Hi, I improved a little the error handling example in the documentation.

The `post` method calls `http`, `http` calls `oAuthRequest`, `oAuthRequest` calls `request` which is possible to throw a `TwitterOAuthException` on a `cURL` error. So, that means when the user calls the `post` method, they also need to add a try catch block to handle that exception.
