### PR TITLE
Update Media section to reflect v2 API changes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+
 ---
 title: TwitterOAuth PHP Library for the Twitter REST API
 layout: base
@@ -214,18 +215,23 @@ $statues = $connection->post("statuses/update", ["status" => "hello world"]);
   <a
     href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update.html"
     >POST media/upload</a
-  >.
+  >. This uses the v1.1 API as there is no v2 equivalent.
+</p>
+<p>
+  Note: When creating the application in the Twitter Developer Portal, you must enable Read and Write privileges under Settings > User authentication settings, as otherwise Tweet creation will fail.
 </p>
 
 <pre>
 $connection = new TwitterOAuth(CONSUMER_KEY, CONSUMER_SECRET, $access_token, $access_token_secret);
+$connection->setApiVersion(1.1);
 $media1 = $connection->upload('media/upload', ['media' => '/path/to/file/kitten1.jpg']);
 $media2 = $connection->upload('media/upload', ['media' => '/path/to/file/kitten2.jpg']);
+$connection->setApiVersion(2);
 $parameters = [
-    'status' => 'Meow Meow Meow',
-    'media_ids' => implode(',', [$media1->media_id_string, $media2->media_id_string])
+    'text' => 'Meow Meow Meow',
+    'media' => ['media_ids' => [$media1->media_id_string, $media2->media_id_string]]
 ];
-$result = $connection->post('statuses/update', $parameters);
+$result = $connection->post('tweets', $parameters, true);
 </pre>
 
 <h3>JSON data</h3>
@@ -330,3 +336,4 @@ $connection->setTimeouts(10, 15);
   </a>
   .
 </p>
+


### PR DESCRIPTION
This reflects the changes to the v2 API:

- API permissions must now be Read and Write
- Tweet posting endpoint now must be v2 but v1.1 for media
- POST to tweets must be JSON
- media_ids is now wrapped in media